### PR TITLE
Fix Bug when Resend Repeating Groups

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -254,6 +254,7 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 
 		session.log.OnEventf("Resending Message: %v", sentMessageSeqNum)
 		msgBytes = msg.build()
+		msgBytes = msg.resendBuild()
 		session.EnqueueBytesAndSend(msgBytes)
 
 		seqNum = sentMessageSeqNum + 1

--- a/message.go
+++ b/message.go
@@ -423,3 +423,26 @@ func (m *Message) cook() {
 	checkSum := (m.Header.total() + m.Body.total() + m.Trailer.total()) % 256
 	m.Trailer.SetString(tagCheckSum, formatCheckSum(checkSum))
 }
+
+func (m *Message) resendBuild() []byte {
+	m.resendCook()
+
+	var b bytes.Buffer
+	m.Header.write(&b)
+	b.Write(m.bodyBytes)
+	m.Trailer.write(&b)
+	return b.Bytes()
+}
+
+func (m *Message) resendCook() {
+	bodyLength := m.Header.length() + len(m.bodyBytes) + m.Trailer.length()
+	m.Header.SetInt(tagBodyLength, bodyLength)
+
+	bodyTotal := 0
+	for _, b := range []byte(m.bodyBytes) {
+		bodyTotal += int(b)
+	}
+
+	checkSum := (m.Header.total() + bodyTotal + m.Trailer.total()) % 256
+	m.Trailer.SetString(tagCheckSum, formatCheckSum(checkSum))
+}

--- a/session.go
+++ b/session.go
@@ -36,7 +36,8 @@ func (n noopDebugger) Debugf(_ string, _ ...interface{}) {}
 
 var Debug Debugger = noopDebugger{}
 
-// The Session is the primary FIX abstraction for message communication
+//The Session is the primary FIX abstraction for message communication
+
 type session struct {
 	store MessageStore
 


### PR DESCRIPTION
Quickfixgo [has an ancient bug](https://github.com/quickfixgo/quickfix/issues/276) that causes repeating groups to not be properly resent. This patch fixes that.

